### PR TITLE
增加作为子模块安装的方式

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 git clone https://github.com/Alex-fun/hexo-theme-jane.git themes/jane
 ```
 
-(optional)作为[git子模块安装](https://yuguo.us/weblog/git-submodule/)
+(optional)作为[git子模块](https://yuguo.us/weblog/git-submodule/)安装
 ```
 git submodule add https://github.com/Alex-fun/hexo-theme-jane.git themes/jane
 ```

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@
 ```
 git clone https://github.com/Alex-fun/hexo-theme-jane.git themes/jane
 ```
+
+(optional)作为[git子模块安装](https://yuguo.us/weblog/git-submodule/)
+```
+git submodule add https://github.com/Alex-fun/hexo-theme-jane.git themes/jane
+```
+
 然后配置根目录的_config.yml文件（并非theme里的那个）
 
 ```


### PR DESCRIPTION
由于许多时候，hexo 的主目录（一般是 blog/）也会作为git目录进行版本控制，这个时候，采用git子模块方式安装，更合理一些。
