### PR TITLE
修复 Archives 页面文章显示不全的问题

### DIFF
--- a/layout/_partial/archive.ejs
+++ b/layout/_partial/archive.ejs
@@ -12,7 +12,7 @@
   <% } %>
 <% } else { %>
   <% var last; %>
-  <% page.posts.each(function(post, i){ %>
+  <% site.posts.reverse().each(function(post, i){ %>
     <% var year = post.date.year(); %>
     <% if (last != year){ %>
       <% if (last != null){ %>
@@ -27,7 +27,7 @@
     <% } %>
     <%- partial('archive-post', {post: post, even: i % 2 == 0}) %>
   <% }) %>
-  <% if (page.posts.length){ %>
+  <% if (site.posts.length){ %>
     </div></section>
   <% } %>
 <% } %>


### PR DESCRIPTION
`page.posts` 只包括主页第一页的文章， `site.posts` 是全部的文章

之前的写法当文章数量大于 10（默认的每页文章数）时后面的就显示不出来了..